### PR TITLE
fix small typos, add links and small updates

### DIFF
--- a/community.html
+++ b/community.html
@@ -74,11 +74,11 @@ ReproNim is dedicated to making neuroimaging research openly reproducible across
                             </p>
 
                             <p>
-We are collaborating with numerous groups around the country and abroad to synergistically develop ReproNim tools in concert with (and as informed by) rapidly advancing technologies in a variety of areas including image analysis, workflow processing, data sourcing and hosting, and associated API developments.  (See Collaborator Projects below.)
+We are collaborating with numerous groups around the country and abroad to synergistically develop ReproNim tools in concert with (and as informed by) rapidly advancing technologies in a variety of areas including image analysis, workflow processing, data sourcing and hosting, and associated API developments (See Collaborator Projects below.).
                             </p>
 
                             <p>
-In parallel, we are working with both basic and clinical researchers with established programs of applied neuroimaging research around the country, as well as large scale informatics initiative in the US and the UK, to guide and refine the practical implementation of ReproNim tools in a variety of real-world research settings.  (See Service Projects below.)
+In parallel, we are working with both basic and clinical researchers with established programs of applied neuroimaging research around the country, as well as large scale informatics initiative in the US and the UK, to guide and refine the practical implementation of ReproNim tools in a variety of real-world research settings (See Service Projects below.).
                             </p>
 
             			</div>
@@ -120,7 +120,7 @@ In parallel, we are working with both basic and clinical researchers with establ
             			</div>
             			<div class="col-md-4">
 <h3>Study Forest data source</h3>
-<p>Prof. Michael Hanke, Ph.D., Otto-von-Guericke University Magdeburg</p>
+<p>Prof. Michael Hanke, Ph.D., Forschungszentrum Jülich</p>
 <p>DFG PO 548/16-1, Deutsche Forschungsgemeinschaft; Tracing the temple: Investigating the representation of perceptual relevance</p>
             			</div>
             			<div class="col-md-4">

--- a/describe.html
+++ b/describe.html
@@ -75,7 +75,7 @@
                             <ul>
                                 <li>Design interoperable Data Models, Workflows and Linked Results</li>
                                 <li>Create reusable workflows with provenance</li>
-                                <li>Test computational reproducibility and robustness.</li>
+                                <li>Test computational reproducibility and robustness</li>
                                 <li>Integrate tools in Brainverse</li>
                             </ul>
                             <p>Neuroimaging data have become richer, with larger cohorts of participants,
@@ -86,7 +86,7 @@
                             <ul>
                                 <li>Interpreting and comparing scientific results and enabling reusable analysis require understanding provenance, i.e. how the data were generated and processed.</li>
                                 <li>To be useful, the provenance must be understandable, easily communicated, and captured automatically in machine accessible form.</li>
-                                <li>The NIDM model specification captures data, analyses details across software and workflow tools, and results. </li>
+                                <li>The <a href="http://nidm.nidash.org/">NIDM</a> specification captures data, analyses details across software and workflow tools, and results. </li>
                             </ul>
                             <p>Currently we are focused on the following projects. You can help us by trying them, contributing to them, or by sharing your ideas on how to improve them.</p>
             			</div>
@@ -115,7 +115,7 @@
 <p>
     These tools will include publishing, visualizing, and validating data
     described using NIDM. It will enable interoperability with existing efforts
-    (e.g., BIDS, DataLad, Nipype).
+    (e.g., <a href="https://bids.neuroimaging.io/">BIDS</a>, <a href="https://www.datalad.org/">DataLad</a>, <a href="https://nipype.readthedocs.io/en/latest/">Nipype</a>).
     <a href="http://doi.org/10.5334/dsj-2017-045">Example: Keator et al., 2017</a>
 </p>
 <ul>

--- a/discover.html
+++ b/discover.html
@@ -114,8 +114,8 @@ The NeuroBlast service will allow users to find matching/similar studies based o
 <ul>
 <li>A web accessible portal for terminologies and common data elements (CDEs)</li>
 <li>Enables users to search for, contribute to and collaborate around terms and CDEs</li>
-<li>Provides term information for semantic annotation based on NeuroImaging data Model
-(NIDM) making experimental neuroimaging study more reproducible, and making data FAIR</li>
+<li>Provides term information for semantic annotation based on the <a href="http://nidm.nidash.org/">NeuroImaging data Model
+(NIDM)</a> making experimental neuroimaging studies more reproducible, and making data FAIR</li>
 </ul>
 
                 </div>
@@ -179,10 +179,10 @@ The NeuroBlast service will allow users to find matching/similar studies based o
                 <p></p>
             </div>
         </div>
-      
+
     </div>
 </section>
-            
+
             <footer class="site-footer">
                 <div>
                     <ul class="list-inline quicklinks">

--- a/do.html
+++ b/do.html
@@ -185,7 +185,7 @@ by <strong>Do</strong>ing</p>
 						<div class="col-sm-4">
 <h3><a href="https://github.com/myyoda">YODA</a> Principles</h3>
 
-<p>YODA (YODA’s organigram on data analysis) outlines an approach for
+<p>YODA (<a href="https://github.com/myyoda"><YODA’s organigram on data analysis</a>) outlines an approach for
   using version control systems such as
   <a href="http://git-scm.org">git</a>,
   <a href="http://git-annex.branchable.com">git-annex</a>,

--- a/index.html
+++ b/index.html
@@ -69,12 +69,12 @@
                     <div class="row">
                         <div class="col-md-4">
                             <p>
-                            The ReproNim vision is to to help neuroimaging researchers to:
+                            The ReproNim vision is to help neuroimaging researchers to:
                             </p>
 
                             <ul>
                             <li>Find and Share data in a <a class="text-danger" href="http://www.nature.com/articles/sdata201618">FAIR</a> fashion (<strong>discover</strong> resources with <strong>NeuroBLAST</strong>)</li>
-                            <li>Comprehensively describe their data and analysis workflows in precisely replicable fashion (<strong>describe</strong> research processes with ReproIN and <strong>BrainVerse</strong>)</li>
+                            <li>Comprehensively describe their data and analysis workflows in a precisely replicable fashion (<strong>describe</strong> research processes with ReproIN and <strong>BrainVerse</strong>)</li>
                             <li>Manage their computational resource options (<strong>do</strong> analysis with <strong>ReproMan</strong>)</li>
                             </ul>
 
@@ -112,31 +112,31 @@
 		<li> Join us for an introduction to <a href="https://scicrunch.org/nidm-terms/interlex/dashboard">InterLex</a> by ReproNIm investigator Jeff Grethe, in his presentation <em>"Damn it Jim, I am a researcher not an ontologist: Exploring and using terminologies"</em>
 <li> <strong>Zoom Meeting</strong>: <a href="https://umassmed.zoom.us/meeting/register/eb4a9fc1a7a734147510d14dfea9e911"><strong>Register</strong></a> in advance to receive a confirmation email with instructions on how to join the meeting
 	<li> <em>[video conference open to the public]</em> Session will also be recorded for those unable to join
-	</ul> 
-	
+	</ul>
+
 <li>    Friday, January 3, 2020 at 2pm EST
 <ul>
 	<li> ReproNim investigator <strong>Dorota Jarecka</strong> presents <em>"Testing scientific workflows with Testkraken"</em>
 	<li> Both the <a href="https://www.youtube.com/watch?v=d5KbmuhvnwE"> Video Presentation</a> and <a href="https://drive.google.com/open?id=1QzcywXi1ThawyxJQLFVGG8hls9H0trOC"> Slides</a> are now available
-	
+
 	</ul>
-		
+
 <li>	Friday, December 6, at 2pm EST
-<ul> 
-        <li> ReproNim investigator <strong>Yaroslav Halchenko</strong> and colleagues present <em>"Taking Control of your DICOM Data: ReproIn/Heudiconv Tools"</em>		
+<ul>
+        <li> ReproNim investigator <strong>Yaroslav Halchenko</strong> and colleagues present <em>"Taking Control of your DICOM Data: ReproIn/Heudiconv Tools"</em>
         <li> Both the <a href="https://www.youtube.com/watch?v=j2SKX37-w4c&list=PLs3CA4ShM1DUX0nTMKfoB8Z6kdrZpByLa&index=5&t=0s"> Video Presentation</a> and <a href="https://docs.google.com/presentation/d/14UNWQVY49c9Xc-7sj1FkoILXnt-wYjW404oqT-FtCW8/edit#slide=id.p"> Slides</a> are now available!
 	</ul>
-	
+
 	<li> Join us on the first Friday of every month, from 2-3pm Eastern Time
 	<li> Featured topics will include important efforts in reproducibility, from both ReproNim and others
 	</ul>
-		
+
 
 <li> New Publication: <a href="https://www.frontiersin.org/articles/10.3389/fninf.2019.00001/full">The ReproNim Perspective on Reproducible Neuroimaging</a>
 </ul>
 </p>
-				
-				
+
+
 				<p><a href="news_archive.html"><strong>News History</strong></a>
 					</p>
                             <h3>Use cases</h3>
@@ -237,7 +237,7 @@ use them in a reproducible and scalable way.
                     </div>
                 </div>
             </section>
-			
+
             <section class="section-5">
                 <div class="container">
                     <div class="row">
@@ -245,7 +245,7 @@ use them in a reproducible and scalable way.
                             <h2 class="section-heading text-center"><a class="fragment-identifier" name="training">Tools</a></h2>
                             <p>We have many tools designed to help the user work through a more reproducible version of their data analysis tasks. These toold support areas such as Data processing, Data ingestion, Standardization, Search, Data Management, Computation, Testing, etc. </p>
                             <!-- <p><a href="reprostack.html">Read more.</a></p> -->
-							<p><a href="https://docs.google.com/document/d/1I1qFuo6aemiZRUGS4KLJF2qieNXGQS1Gr-u_ti8ZK78/">Read more.</a></p> 
+							<p><a href="https://docs.google.com/document/d/1I1qFuo6aemiZRUGS4KLJF2qieNXGQS1Gr-u_ti8ZK78/">Read more.</a></p>
                         </div>
                     </div>
                 </div>

--- a/teach.html
+++ b/teach.html
@@ -71,7 +71,7 @@
                             <p>Our Educational Objectives include:</p>
                             <ul>
                                 <li>Topical training in the overall issues that affect the reproducibility of neuroimaging research (data acquisition and characterization, experimental methods, analyses, record keeping and reporting, reusability, and sharing of data and methods)</li>
-                                <li>Development of a next-generation cadre of software developers that are versed in the techniques that promote reproducibility and education of the neuroimaging researcher in the tools that promote complete experimental description.</li>
+                                <li>Development of a next-generation cadre of software developers that are versed in the techniques that promote reproducibility and education of neuroimaging researchers in the tools that promote complete experimental description.</li>
                                 <li>Train the trainer:  we adopted the software and data carpentry philosophy and work to train individuals who will themselves train others.</li>
                             </ul>
                             <p>Our initial (Phase 1) curriculum focuses on developing material that address reproducibility in four areas: </p>
@@ -80,14 +80,14 @@
   				<li>Computational basics</li>
   				<li>Reproducible workflows</li>
   				<li>Statistical tools</li>
-			    </ul> 
-			    <p>   
+			    </ul>
+			    <p>
  in order to initiate a set of tools and practices that are reproducibility-enabled. Future curricula will extend the reach of these materials to encompass a broader community of researchers and will feature more training material on the tools developed by the ReproNim project.</p>
 	<p>
 	We are developing the following forms of training:
 	<ul>
 		<li>Our curriculum is developed on <strong>Github</strong>; each of the modules is accessible from the sections below.
-		<li>In addition, this material is offered as a <strong>Moodle</strong> Course, accessible <a href="https://courses.repronim.org"> here</a>. 
+		<li>In addition, this material is offered as a <strong>Moodle</strong> Course, accessible <a href="https://courses.repronim.org"> here</a>.
 		<li><a href="http://www.repronim.org/fellowship"><strong>ReproNim/INCF Training Fellowship</strong></a>; a Train-the-Trainer program to empower
 			researchers to teach reproducible methods to others.
 	</ul>
@@ -102,29 +102,29 @@
             			<div class="col-md-4">
             				<h2>ReproNim Introduction</h2>
                             <p>Why do we care about reproducibility?  Can we do anything to improve the reproducibility of our neuroimaging work? Let's get motivated to change the world!</p>
-                            <p><a href="http://www.repronim.org/module-intro/">Goto module.</a></p>
+                            <p><a href="http://www.repronim.org/module-intro/">Go to module.</a></p>
             			</div>
             			<div class="col-md-4">
             				<h2>Reproducibility Basics</h2>
                             <p>Shells, version control, package managers, and other tools to embrace "Reproducibility By Design"!</p>
-                            <p><a href="http://www.repronim.org/module-reproducible-basics/">Goto module.</a></p>
+                            <p><a href="http://www.repronim.org/module-reproducible-basics/">Go to module.</a></p>
             			</div>
             			<div class="col-md-4">
             				<h2>FAIR Data</h2>
                             <p>FAIR is a collection of guiding principles to make data Findable, Accessible, Interoperable, and Re-usable. We look at ways to ensure that a researcher’s data is properly managed and published in support of reproducible research.</p>
-                            <p><a href="http://www.repronim.org/module-FAIR-data/">Goto module.</a></p>
+                            <p><a href="http://www.repronim.org/module-FAIR-data/">Go to module.</a></p>
             			</div>
             		</div><!-- row -->
             		<div class="row">
             			<div class="col-md-4">
             				<h2>Data Processing</h2>
-                            <p>What do we need to know to conduct reproducible analysis? Learn to: Annotate, harmonize, clean, and version data; and Create and maintain reproducible computational environments.</p>
-                            <p><a href="http://www.repronim.org/module-dataprocessing/">Goto module.</a></p>
+                            <p>What do we need to know to conduct reproducible analysis? Learn to: Annotate, harmonize, clean, and version data; and create and maintain reproducible computational environments.</p>
+                            <p><a href="http://www.repronim.org/module-dataprocessing/">Go to module.</a></p>
             			</div>
             			<div class="col-md-4">
             				<h2>Statistics</h2>
                             <p>Here we describe some key statistical concepts, and how to use them to make your research more reproducible. Everything you ever wanted to know about power, effect size, P-values, sampling and everything else.</p>
-                            <p><a href="http://www.repronim.org/module-stats/">Goto module.</a></p>
+                            <p><a href="http://www.repronim.org/module-stats/">Go to module.</a></p>
             			</div>
             		</div><!-- row -->
             	</div>


### PR DESCRIPTION
- this PR fixes some small typos, adds links and introduces small updates
- remove second "to" in first sentence of landing page
- changed "... in precisely ..." to "... in a precisely ..." in second bullet point on the landing page 
- on "Discover" site, "Interlex" section, last bullet point: added "the", add NIDM link and changed "study" to "studies"
- on "Describe" site: removed dot from third bullet point
- on "describe" site, "NIDM" section: added links to NIDM, BIDS, DataLad and Nipype
- on "Do" site, "YODA" section: added YODA organigram link
- on "Teach" site, second bullet point: changed "the neuroimaging researcher" to "neuroimaging researchers"
- on "Teach" site, module links: changed "Goto" to "Go to"
- on "Teach" site, data processing section: changed "Create" to "create"
- on "Community" site, second bullet point: removed dot 
- on "Community" site, "Collaborator projects" section: update Michael's affiliation


Question: on "Do" site, "Reproman" section: the last bullet point appears to missing something / stops at an unwanted point. Does anyone have insights what should be written there?