### PR TITLE
ENH: add "search.html" page to perform search using google custom search engine

### DIFF
--- a/2019_training_logistics.html
+++ b/2019_training_logistics.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div><!-- /.navbar-collapse -->
                                 </nav>

--- a/5Steps/acquisition.html
+++ b/5Steps/acquisition.html
@@ -49,6 +49,7 @@
                                             <li><a href="../do.html">Do</a></li>
                                             <li><a href="../teach.html">Teach</a></li>
                                             <li><a href="../community.html">Community</a></li>
+                                            <li><a href="../search.html">🔍</a></li>
                                         </ul>
                                     </div>
 

--- a/5Steps/design.html
+++ b/5Steps/design.html
@@ -49,6 +49,7 @@
                                             <li><a href="../do.html">Do</a></li>
                                             <li><a href="../teach.html">Teach</a></li>
                                             <li><a href="../community.html">Community</a></li>
+                                            <li><a href="../search.html">🔍</a></li>
                                         </ul>
                                     </div>
 

--- a/5Steps/processing.html
+++ b/5Steps/processing.html
@@ -49,6 +49,7 @@
                                             <li><a href="../do.html">Do</a></li>
                                             <li><a href="../teach.html">Teach</a></li>
                                             <li><a href="../community.html">Community</a></li>
+                                            <li><a href="../search.html">🔍</a></li>
                                         </ul>
                                     </div>
 

--- a/5Steps/publication.html
+++ b/5Steps/publication.html
@@ -49,6 +49,7 @@
                                             <li><a href="../do.html">Do</a></li>
                                             <li><a href="../teach.html">Teach</a></li>
                                             <li><a href="../community.html">Community</a></li>
+                                            <li><a href="../search.html">🔍</a></li>
                                         </ul>
                                     </div>
 

--- a/5Steps/stats.html
+++ b/5Steps/stats.html
@@ -49,6 +49,7 @@
                                             <li><a href="../do.html">Do</a></li>
                                             <li><a href="../teach.html">Teach</a></li>
                                             <li><a href="../community.html">Community</a></li>
+                                            <li><a href="../search.html">🔍</a></li>
                                         </ul>
                                     </div>
 

--- a/5steps.html
+++ b/5steps.html
@@ -49,6 +49,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div>
 

--- a/community.html
+++ b/community.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div>
                                         <!-- /.navbar-collapse -->

--- a/describe.html
+++ b/describe.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div>
                                           <!-- /.navbar-collapse -->

--- a/discover.html
+++ b/discover.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div><!-- /.navbar-collapse -->
                                 </nav>

--- a/do.html
+++ b/do.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div><!-- /.navbar-collapse -->
                                 </nav>

--- a/events.html
+++ b/events.html
@@ -49,6 +49,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div>
 -->

--- a/fellowship.html
+++ b/fellowship.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div><!-- /.navbar-collapse -->
                                 </nav>

--- a/how-would-repronim.html
+++ b/how-would-repronim.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div><!-- /.navbar-collapse -->
                                 </nav>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div>
                                           <!-- /.navbar-collapse -->

--- a/news_archive.html
+++ b/news_archive.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div><!-- /.navbar-collapse -->
                                 </nav>

--- a/publications.html
+++ b/publications.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div><!-- /.navbar-collapse -->
                                 </nav>

--- a/search.html
+++ b/search.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div>
                                         <!-- /.navbar-collapse -->

--- a/search.html
+++ b/search.html
@@ -67,8 +67,18 @@
             			</div>
             		</div><!-- row -->
             		<div class="row">
-					  <script async src="https://cse.google.com/cse.js?cx=011585779972124617449:lngfk9yjbrv"></script>
-					  <div class="gcse-search"></div>
+            			<div class="col-md-12">
+            			  <h2>this website:</h2>
+            			  <script async src="https://cse.google.com/cse.js?cx=011585779972124617449:lngfk9yjbrv"></script>
+            			  <div class="gcse-search"></div>
+            			</div>
+            		</div>
+            		<div class="row">
+            			<div class="col-md-12">
+            			  <h2>larger ReproNim ecosystem:</h2>
+            			  <script async src="https://cse.google.com/cse.js?cx=011585779972124617449:nhlyoiogpg7"></script>
+            			  <div class="gcse-search"></div>
+            			</div>
             		</div>
             	</div>
             </section>

--- a/search.html
+++ b/search.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132556733-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'UA-132556733-1');
+        </script>
+
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Search - ReproNim</title>
+
+        <!-- CSS -->
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+        <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/1.5.2/css/ionicons.min.css">
+        <link rel="stylesheet" href="css/style.css">
+
+        <!-- font -->
+        <link href='https://fonts.googleapis.com/css?family=Nova+Square' rel='stylesheet'>
+        <link rel="stylesheet" href="font/font.css">
+    </head>
+    <body>
+        <div id="wrapper">
+            <section class="section-1">
+                <header class="site-header">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-sm-4 col-xs-8">
+                                <h1 class="logo"><a href="index.html">ReproNim</a></h1>
+                            </div>
+                            <div class="col-sm-8 col-xs-4">
+                                <nav class="navbar pull-right" role="navigation">
+                                    <!-- Brand and toggle get grouped for better mobile display -->
+                                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+                                        <span class="ion-navicon"></span>
+                                    </button>
+
+                                    <!-- Collect the nav links, forms, and other content for toggling -->
+                                    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+                                        <ul class="nav navbar-nav">
+                                            <li><a href="discover.html">Discover</a></li>
+                                            <li><a href="describe.html">Describe</a></li>
+                                            <li><a href="do.html">Do</a></li>
+                                            <li><a href="teach.html">Teach</a></li>
+                                            <li><a href="community.html">Community</a></li>
+                                        </ul>
+                                    </div>
+                                        <!-- /.navbar-collapse -->
+                                </nav>
+                            </div>
+                        </div>  <!-- row -->
+                    </div>
+                </header>   <!-- site header -->
+            </section>
+
+            <section>
+            	<div class="container">
+            		<div class="row">
+            			<div class="col-md-12">
+            				<h1 class="main-page-header">Search</h1>
+            			</div>
+            		</div><!-- row -->
+            		<div class="row">
+					  <script async src="https://cse.google.com/cse.js?cx=011585779972124617449:lngfk9yjbrv"></script>
+					  <div class="gcse-search"></div>
+            		</div>
+            	</div>
+            </section>
+
+            <footer class="site-footer">
+                <div>
+                    <ul class="list-inline quicklinks">
+                    <li>Copyright &copy; ReproNim 2016-2020</div>
+                    <li>Support: <a href="https://projectreporter.nih.gov/project_info_description.cfm?aid=8999833">NIH-NIBIB P41 EB019936</a></li>
+                    <li>Site theme: themewagon.com</li>
+                    </ul>
+                </div>
+            </footer>
+        </div>  <!-- wrapper -->
+
+        <!-- js -->
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+    </body>
+</html>

--- a/teach.html
+++ b/teach.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div>
                                         <!-- /.navbar-collapse -->

--- a/template.html
+++ b/template.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div><!-- /.navbar-collapse -->
                                 </nav>

--- a/use_cases.html
+++ b/use_cases.html
@@ -49,6 +49,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div>
 -->

--- a/webinar-series.html
+++ b/webinar-series.html
@@ -48,6 +48,7 @@
                                             <li><a href="do.html">Do</a></li>
                                             <li><a href="teach.html">Teach</a></li>
                                             <li><a href="community.html">Community</a></li>
+                                            <li><a href="search.html">🔍</a></li>
                                         </ul>
                                     </div><!-- /.navbar-collapse -->
                                 </nav>


### PR DESCRIPTION
As amount of referenced materials grew, it became hard(er) to locate specific content.
We need some search functionality.

The easiest way AFAIK is just to offload it to google.  E.g. https://git-annex.branchable.com/ does that.  Pretty much we could just make a form which issues request to google search while adding `site:www.repronim.org` restriction, and that is what this new search page is doing - just via registered custom google search engine.

Pros: seems to work quite nicely -- searches into presentations etc

Cons: once in a while ads will appear/be on top of the list of hits.

Someone could make it fancier, embed into the website better -- but that IMHO should be done after some (ie this) search capability added at least, or might not happen at all. 

PS If later menu to be extended the datalad run recorded command in the 2nd commit  message (3d0767c519c4deb21ef85f7dc75e8529e230507f) could be of help