### PR TITLE
Replace Moodle link with downtime note

### DIFF
--- a/teach.html
+++ b/teach.html
@@ -88,7 +88,7 @@
 	We are developing the following forms of training:
 	<ul>
 		<li>Our curriculum is developed on <a href="https://github.com/ReproNim?q=module">GitHub</a>; each of the modules is accessible from the sections below.
-		<li>In addition, this material is offered as a <strong>Moodle</strong> Course, accessible <a href="https://courses.repronim.org"> here</a>.
+		<li>In addition, this material will be continued to be offered as a <strong>Moodle</strong> Course (currently unavailable while upgrades are in progress).
 		<li><a href="http://www.repronim.org/fellowship"><strong>ReproNim/INCF Training Fellowship</strong></a>; a Train-the-Trainer program to empower
 			researchers to teach reproducible methods to others.
 	</ul>


### PR DESCRIPTION
As far as I can tell, this one affects only teach.html.  I've removed the link to the moodle (currently down) and noted the downtime.